### PR TITLE
Fixed infinite loop of null splitter ( + tests )

### DIFF
--- a/src/split_input.rs
+++ b/src/split_input.rs
@@ -1,6 +1,6 @@
 use std::str::SplitWhitespace;
 
-pub(crate) struct NullSplitter<'a> {
+pub struct NullSplitter<'a> {
     buffer: &'a [u8],
 }
 
@@ -8,15 +8,26 @@ impl<'a> Iterator for NullSplitter<'a> {
     type Item = &'a str;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut output: &[u8] = &self.buffer[0..0];
-        for i in 0..self.buffer.len() {
-            output = &self.buffer[..i];
-            if self.buffer[i] == 0 {
-                self.buffer = &self.buffer[i + 1..];
-                break;
+        let null_index = self
+            .buffer
+            .iter()
+            .position(|&b| b == 0);
+        let output = match null_index {
+            None => {
+                if self.buffer.is_empty() {
+                    return None;
+                }
+                let output = self.buffer;
+                self.buffer = &[];
+                output
             }
-        }
-        Some(output.utf8_chunks().next()?.valid())
+            Some(null_index) => {
+                let (output, rest) = self.buffer.split_at(null_index);
+                self.buffer = &rest[1.min(self.buffer.len())..];
+                output
+            }
+        };
+        output.utf8_chunks().next().map(|c| c.valid())
     }
 }
 
@@ -44,5 +55,56 @@ impl<'a> Iterator for Splitter<'a> {
             Splitter::Null(null_splitter) => null_splitter.next(),
             Splitter::Whitespace(split_whitespace) => split_whitespace.next(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn null_splitter() {
+        let buffer = b"foo\0bar\0baz\0";
+        let result: Vec<_> = Splitter::null(buffer).collect();
+        assert_eq!(result, vec!["foo", "bar", "baz"]);
+    }
+
+    #[test]
+    fn null_splitter_no_null() {
+        let buffer = b"foo bar baz";
+        let result: Vec<_> = Splitter::null(buffer).collect();
+        assert_eq!(result, vec!["foo bar baz"]);
+    }
+
+    #[test]
+    fn whitespace_splitter() {
+        let buffer = b"foo bar baz";
+        let result: Vec<_> = Splitter::whitespace(buffer).collect();
+        assert_eq!(result, vec!["foo", "bar", "baz"]);
+    }
+
+    #[test]
+    fn whitespace_splitter_no_whitespace() {
+        let buffer = b"foo\0bar\0baz\0";
+        let result: Vec<_> = Splitter::whitespace(buffer).collect();
+        assert_eq!(result, vec!["foo\0bar\0baz\0"]);
+    }
+
+    #[test]
+    fn splitter_empty() {
+        let buffer = b"";
+        let result = Splitter::null(buffer).collect::<Vec<_>>();
+        assert_eq!(result, Vec::<&str>::new());
+        let result: Vec<_> = Splitter::whitespace(buffer).collect();
+        assert_eq!(result, Vec::<&str>::new());
+    }
+
+    #[test]
+    fn bad_utf8() {
+        let buffer = b"foo\xFFbar";
+        let result: Vec<_> = Splitter::null(buffer).collect();
+        assert_eq!(result, vec!["foo"]);
+        let result: Vec<_> = Splitter::whitespace(buffer).collect();
+        assert_eq!(result, vec!["foo"]);
     }
 }


### PR DESCRIPTION
This PR was initially meant to only add some sanity tests, but they revealed an infinite loop in some cases, so this PR now also fixes that.

Previously: 

```console
test split_input::tests::bad_utf8 ... ignored, infinite loop
test split_input::tests::null_splitter_no_null ... ignored, infinite loop
test split_input::tests::splitter_empty ... ok
test split_input::tests::null_splitter ... ok
test split_input::tests::whitespace_splitter_no_whitespace ... ok
test split_input::tests::whitespace_splitter ... ok
```

Now: 
```console
test split_input::tests::bad_utf8 ... ok
test split_input::tests::splitter_empty ... ok
test split_input::tests::whitespace_splitter_no_whitespace ... ok
test split_input::tests::null_splitter_no_null ... ok
test split_input::tests::null_splitter ... ok
test split_input::tests::whitespace_splitter ... ok
```
