### PR TITLE
Spawn commands in parallel without rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,6 @@ dependencies = [
  "clap",
  "crossterm",
  "ratatui",
- "rayon",
 ]
 
 [[package]]
@@ -166,31 +165,6 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -464,26 +438,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,3 @@ anyhow = "1.0.95"
 clap = { version = "4.5.26", features = ["derive"] }
 crossterm = "0.28.1"
 ratatui = "0.29.0"
-rayon = "1.10.0"

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,16 +1,147 @@
-use std::process::{self, Command};
+use crate::{split_input::Splitter, Options};
+use std::{process, thread, time::Duration};
 
-pub fn exec(program: &str, program_args: &[String], items: Vec<&str>) {
-    let status = Command::new(program)
-        .args(program_args)
-        .args(&items)
-        .status()
-        .expect("command could not be spawned");
-    match status.code() {
-        None | Some(0) => (),
-        Some(code) => {
-            eprintln!("Command {program} {program_args:?} {items:?} failed with status {code}");
-            process::exit(code);
+/// A trait for anything that takes our `Options` struct as an argument
+/// and returns a list of exit statuses of spawned child processes
+pub trait Executor {
+    fn execute(
+        self,
+        options: &Options,
+        inputs: Splitter,
+    ) -> anyhow::Result<Vec<process::ExitStatus>>;
+}
+
+/// Runs the child processes in sequence, waiting for each to finish before starting the next
+pub struct Sequential;
+impl Executor for Sequential {
+    /// # Errors
+    /// Will return an error if either:
+    /// - The input buffer cannot be read from stdin
+    /// - One of the child processes fails to start (at which point the function will return early)
+    fn execute(
+        self,
+        options: &Options,
+        inputs: Splitter,
+    ) -> anyhow::Result<Vec<process::ExitStatus>> {
+        inputs
+            .chunks(options.nargs)
+            .map(|child_args| {
+                process::Command::new(&options.program)
+                    .args(&options.program_args)
+                    .args(child_args)
+                    .stdin(process::Stdio::null()) // Make sure the child doesn't read from *our* stdin
+                    .status()
+                    .map_err(Into::into)
+            })
+            .collect()
+    }
+}
+
+/// Runs the child processes in parallel, waiting for all to finish before returning
+pub struct Parallel;
+impl Executor for Parallel {
+    /// # Errors
+    /// Will only return an error if the input buffer cannot be read from stdin.
+    /// Failures to start child processes are (currently) only handled by printing an error message to stderr.
+    fn execute(
+        self,
+        options: &Options,
+        inputs: Splitter,
+    ) -> anyhow::Result<Vec<process::ExitStatus>> {
+        let mut running = vec![];
+        for child_args in inputs.chunks(options.nargs) {
+            let child = process::Command::new(&options.program)
+                .args(&options.program_args)
+                .args(&child_args)
+                .stdin(process::Stdio::null()) // Make sure the child doesn't read from *our* stdin
+                .spawn();
+            match child {
+                Ok(child) => running.push(child),
+                Err(e) => eprintln!(
+                    "Failed to start process ({} {}): {e}",
+                    options.program,
+                    child_args.join(" ")
+                ),
+            }
         }
+
+        let mut exited = Vec::with_capacity(running.len());
+        let mut checked = Vec::with_capacity(running.len());
+        while !running.is_empty() {
+            // Wait for all child processes to finish
+            while let Some(mut child) = running.pop() {
+                // `Child.try_wait` is non-blocking, so is essentially a poll
+                match child.try_wait() {
+                    Ok(Some(status)) => exited.push(status), // Child process has exited
+                    Ok(None) => checked.push(child),         // Child process is still running
+                    Err(e) => eprintln!("Error checking child status ({child:?}): {e}"),
+                }
+            }
+            // Sleep for a bit to avoid busy-waiting
+            // 10ms is an arbitrary value, however ~16ms is enough for a 60fps refresh rate
+            thread::sleep(Duration::from_millis(10));
+
+            // Put the checked processes back into the running list, to check again
+            running.extend(checked.drain(..));
+        }
+        Ok(exited)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Mode;
+    use std::time::{Duration, Instant};
+    const MOCK_STDIN: &[u8] = b"0.1 0.2 0.3";
+    const TOTAL_SLEEP: f64 = 0.6;
+
+    fn test_options(mode: Mode) -> Options {
+        Options {
+            nul: false,
+            nargs: 1,
+            mode,
+            program: "sleep".to_string(),
+            program_args: vec![],
+        }
+    }
+
+    #[test]
+    fn test_sequential() {
+        let start_time = Instant::now();
+        let statuses = Sequential
+            .execute(
+                &test_options(Mode::Simple),
+                Splitter::whitespace(MOCK_STDIN),
+            )
+            .unwrap();
+        let total_time = Instant::now() - start_time;
+        assert_eq!(statuses.len(), 3);
+        assert!(statuses.iter().all(|status| status.success()));
+        // The total time should be *at least* the *sum* of all sleeps
+        assert!(
+            total_time >= Duration::from_secs_f64(TOTAL_SLEEP),
+            "{total_time:?}"
+        );
+    }
+
+    #[test]
+    fn test_parallel() {
+        let start_time = Instant::now();
+        let statuses = Parallel
+            .execute(
+                &test_options(Mode::Parallel),
+                Splitter::whitespace(MOCK_STDIN),
+            )
+            .unwrap();
+        let total_time = Instant::now() - start_time;
+        assert_eq!(statuses.len(), 3);
+        assert!(statuses.iter().all(|status| status.success()));
+        // The total time should only be as long as the longest sleep
+        // Testing for *less* than the *sum* of all sleeps to account for variable system load
+        assert!(
+            total_time < Duration::from_secs_f64(TOTAL_SLEEP),
+            "{total_time:?}"
+        );
     }
 }


### PR DESCRIPTION
Hi again,

This PR uses [`spawn`](https://doc.rust-lang.org/std/process/struct.Command.html#method.spawn) to create child processes without blocking on each one until it exits, so it removes the unnecessary `rayon` dependency.

This PR is a bit opinionated, and I took some design choices (such as the [`Executor`](https://github.com/ofersadan85/arrgs/blob/fa38780b56307f50c9bfdcc7dd199fddd703c49a/src/exec.rs#L4-L12) trait) so I would understand if you would want to implement this yourself or go in another direction entirely. In that case think of this as just my suggestion or otherwise tell me how you would like to change it to fit better.

Seeing as you were about to implement the "TUI" I didn't want to step on anything you intend for that so that part is untouched. That being said I think you could get some ideas from the [`Parallel.execute`](https://github.com/ofersadan85/arrgs/blob/fa38780b56307f50c9bfdcc7dd199fddd703c49a/src/exec.rs#L40-L89) function on where you could "catch" the child process output, to be used in the TUI later on (`spawn` returns a handle to the child process that can be used to get to that process' `stdout`, `stderr` etc.)

Also, added tests :blush: